### PR TITLE
Play playlist tracks, load full contents, fix wrong-playlist sync

### DIFF
--- a/src/api/spotify.ts
+++ b/src/api/spotify.ts
@@ -75,6 +75,23 @@ export const spotify = {
   getPlaylist: (playlistId: string) =>
     call<SpotifyPlaylist>(`/playlists/${playlistId}`),
 
+  getPlaylistTracks: async (playlistId: string): Promise<SpotifyTrack[]> => {
+    const all: SpotifyTrack[] = [];
+    let offset = 0;
+    const limit = 100;
+    while (true) {
+      const r = await call<{ items: { track: SpotifyTrack | null }[]; next: string | null }>(
+        `/playlists/${playlistId}/tracks?limit=${limit}&offset=${offset}`
+      );
+      for (const item of r.items) {
+        if (item.track) all.push(item.track);
+      }
+      if (!r.next) break;
+      offset += limit;
+    }
+    return all;
+  },
+
   createPlaylist: (userId: string, name: string, description = '') =>
     call<SpotifyPlaylist>(`/users/${userId}/playlists`, {
       method: 'POST',

--- a/src/components/Discovery.tsx
+++ b/src/components/Discovery.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { SearchBar } from './SearchBar';
 import { SimilarArtistsList } from './SimilarArtistsList';
 import { ArtistView } from './ArtistView';
@@ -23,7 +23,9 @@ export function Discovery({ user }: { user: SpotifyUser }) {
   const [similarError, setSimilarError] = useState<string | null>(null);
 
   const [selectedArtist, setSelectedArtist] = useState<SpotifyArtist | null>(null);
-  const [playingTrack, setPlayingTrack] = useState<SpotifyTrack | null>(null);
+  // Scoped so a track that's both in the artist list and the playlist column
+  // doesn't try to play in two iframes at once.
+  const [playing, setPlaying] = useState<{ trackId: string; scope: 'artist' | 'playlist' } | null>(null);
 
   const [likedTracks, setLikedTracks] = useState<SpotifyTrack[]>([]);
   const [playlist, setPlaylist] = useState<SpotifyPlaylist | null>(null);
@@ -35,16 +37,32 @@ export function Discovery({ user }: { user: SpotifyUser }) {
   // the similar list so we have artist images and skip a roundtrip on click.
   const [enrichments, setEnrichments] = useState<Record<string, SpotifyArtist | null>>({});
 
-  // When a playlist is loaded, prime liked tracks from its current contents.
+  // Mirrors `playlist` so add/remove handlers always use the latest selected
+  // playlist id even if a stale closure ever fires.
+  const playlistRef = useRef<SpotifyPlaylist | null>(null);
+  useEffect(() => { playlistRef.current = playlist; }, [playlist]);
+
+  // When a playlist is loaded, fetch all of its tracks (paginated) so we show
+  // existing contents from prior sessions, not just the first 100.
+  const tracksFetchToken = useRef(0);
   useEffect(() => {
     if (!playlist) {
       setLikedTracks([]);
       return;
     }
-    const tracks = (playlist.tracks.items ?? [])
+    // Prime with whatever the playlist response already gave us so the user
+    // sees something immediately, then overwrite once the full fetch returns.
+    const seed = (playlist.tracks.items ?? [])
       .map((i) => i.track)
       .filter((t): t is SpotifyTrack => Boolean(t));
-    setLikedTracks(tracks);
+    setLikedTracks(seed);
+
+    const myToken = ++tracksFetchToken.current;
+    spotify.getPlaylistTracks(playlist.id)
+      .then((tracks) => {
+        if (tracksFetchToken.current === myToken) setLikedTracks(tracks);
+      })
+      .catch(() => { /* keep the seed; next add/remove will sync */ });
   }, [playlist?.id]);
 
   const loadSimilar = useCallback(async (name: string) => {
@@ -92,10 +110,11 @@ export function Discovery({ user }: { user: SpotifyUser }) {
   const onLike = async (track: SpotifyTrack) => {
     if (likedTracks.find((t) => t.id === track.id)) return;
     setLikedTracks((prev) => [...prev, track]);
-    if (playlist) {
+    const current = playlistRef.current;
+    if (current) {
       setStatus('syncing');
       try {
-        await spotify.addTracksToPlaylist(playlist.id, [track.uri]);
+        await spotify.addTracksToPlaylist(current.id, [track.uri]);
         setStatus('saved');
       } catch {
         setStatus('errored');
@@ -105,10 +124,11 @@ export function Discovery({ user }: { user: SpotifyUser }) {
 
   const onDislike = async (track: SpotifyTrack) => {
     setLikedTracks((prev) => prev.filter((t) => t.id !== track.id));
-    if (playlist) {
+    const current = playlistRef.current;
+    if (current) {
       setStatus('syncing');
       try {
-        await spotify.removeTracksFromPlaylist(playlist.id, [track.uri]);
+        await spotify.removeTracksFromPlaylist(current.id, [track.uri]);
         setStatus('saved');
       } catch {
         setStatus('errored');
@@ -116,8 +136,10 @@ export function Discovery({ user }: { user: SpotifyUser }) {
     }
   };
 
-  const onPlay = (track: SpotifyTrack) => {
-    setPlayingTrack(playingTrack?.id === track.id ? null : track);
+  const togglePlay = (track: SpotifyTrack, scope: 'artist' | 'playlist') => {
+    setPlaying((prev) =>
+      prev?.trackId === track.id && prev?.scope === scope ? null : { trackId: track.id, scope }
+    );
   };
 
   const likedIds = new Set(likedTracks.map((t) => t.id));
@@ -143,8 +165,8 @@ export function Discovery({ user }: { user: SpotifyUser }) {
             likedTrackIds={likedIds}
             onLike={onLike}
             onDislike={onDislike}
-            onPlay={onPlay}
-            playingTrackId={playingTrack?.id ?? null}
+            onPlay={(t) => togglePlay(t, 'artist')}
+            playingTrackId={playing?.scope === 'artist' ? playing.trackId : null}
           />
         ) : (
           <div className="empty">
@@ -159,6 +181,9 @@ export function Discovery({ user }: { user: SpotifyUser }) {
           setPlaylist={setPlaylist}
           likedTracks={likedTracks}
           status={status}
+          onRemove={onDislike}
+          onPlay={(t) => togglePlay(t, 'playlist')}
+          playingTrackId={playing?.scope === 'playlist' ? playing.trackId : null}
         />
       </div>
       {recentOpen && (

--- a/src/components/PlaylistView.tsx
+++ b/src/components/PlaylistView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { spotify } from '../api/spotify';
 import type { SpotifyPlaylist, SpotifyTrack, SpotifyUser } from '../types';
+import { TrackRow } from './TrackRow';
 
 type Status = 'idle' | 'syncing' | 'saved' | 'errored';
 
@@ -10,12 +11,18 @@ export function PlaylistView({
   setPlaylist,
   likedTracks,
   status,
+  onRemove,
+  onPlay,
+  playingTrackId,
 }: {
   user: SpotifyUser;
   playlist: SpotifyPlaylist | null;
   setPlaylist: (p: SpotifyPlaylist | null) => void;
   likedTracks: SpotifyTrack[];
   status: Status;
+  onRemove: (track: SpotifyTrack) => void;
+  onPlay: (track: SpotifyTrack) => void;
+  playingTrackId: string | null;
 }) {
   const [userPlaylists, setUserPlaylists] = useState<SpotifyPlaylist[]>([]);
   const [loadingList, setLoadingList] = useState(false);
@@ -114,10 +121,15 @@ export function PlaylistView({
           </div>
           <ul className="playlist-tracks">
             {likedTracks.map((t) => (
-              <li key={t.id} className="playlist-track">
-                <span className="playlist-track-name">{t.name}</span>
-                <span className="muted small">{t.artists[0]?.name}</span>
-              </li>
+              <TrackRow
+                key={t.id}
+                track={t}
+                liked
+                playing={playingTrackId === t.id}
+                onLike={() => { /* unreachable: liked is always true here */ }}
+                onDislike={() => onRemove(t)}
+                onPlay={() => onPlay(t)}
+              />
             ))}
             {likedTracks.length === 0 && (
               <li className="muted">Like tracks in the middle column to add them here.</li>

--- a/src/styles.css
+++ b/src/styles.css
@@ -342,16 +342,7 @@ img { display: block; }
 .status-saved { color: var(--accent); }
 .status-errored { color: var(--danger); }
 
-.playlist-tracks { display: flex; flex-direction: column; gap: 6px; flex: 1; min-height: 0; overflow-y: auto; padding-right: 4px; }
-.playlist-track {
-  display: flex;
-  flex-direction: column;
-  padding: 6px 8px;
-  border-radius: 6px;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-}
-.playlist-track-name { font-weight: 500; }
+.playlist-tracks { display: flex; flex-direction: column; gap: 4px; flex: 1; min-height: 0; overflow-y: auto; padding-right: 4px; }
 
 /* --- shared --- */
 .muted { color: var(--text-muted); }


### PR DESCRIPTION
## Summary
- Playlist column tracks render via `TrackRow` so you can audition them inline and remove with the heart.
- `/playlists/{id}/tracks` is paginated, so playlists with more than 100 songs surface all of their existing contents, not just the first page.
- Playback state is scoped to its column, so a track that's both in the artist list and the playlist doesn't spawn two playing iframes.
- Add/remove now reads playlist id from a ref + a fetch token guards against stale results — kills the path where switching playlists mid-flow could land writes on the previously-selected one.

## Test plan
- [ ] Open an existing playlist with >100 tracks; confirm all tracks show after a brief flicker (seed → full fetch).
- [ ] Click a playlist track — inline player opens and autoplays.
- [ ] While a playlist track is playing, click an artist top-track — playlist track stops, artist track plays.
- [ ] Open playlist A, click "← change playlist", open playlist B, like a track in the artist column — track lands in B (verify in Spotify).
- [ ] Heart on a playlist track removes it from the playlist on Spotify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)